### PR TITLE
fixes undefined @old_from

### DIFF
--- a/lib/sup/modes/edit_message_mode.rb
+++ b/lib/sup/modes/edit_message_mode.rb
@@ -131,6 +131,7 @@ EOS
     HookManager.run "before-edit", :header => @header, :body => @body
 
     @account_selector = nil
+    @old_from = nil
     # only show account selector if there is more than one email address
     if $config[:account_selector] && AccountManager.user_emails.length > 1
       ## Duplicate e-mail strings to prevent a "can't modify frozen
@@ -265,7 +266,7 @@ EOS
   def edit_message
     return false if warn_editing
 
-    old_from = @header["From"] if @account_selector
+    @old_from = @header["From"] if @account_selector
 
     begin
       save_message_to_file
@@ -397,7 +398,7 @@ protected
     @header = header - NON_EDITABLE_HEADERS
     set_sig_edit_flag
 
-    if @account_selector and @header["From"] != old_from
+    if @account_selector and @header["From"] != @old_from
       @account_user = @header["From"]
       @account_selector.set_to nil
     end


### PR DESCRIPTION
This is regarding the issue I emailed you about:

```
----------------------------------------------------------------
--- NameError from thread: main
undefined local variable or method `old_from' for #<Redwood::ComposeMode:0x00000004311088>
/home/amk/Opt/sup/lib/sup/modes/edit_message_mode.rb:400:in `start_edit'
/home/amk/Opt/sup/lib/sup/modes/edit_message_mode.rb:291:in `edit_message'
/home/amk/Opt/sup/lib/sup/modes/edit_message_mode.rb:253:in `default_edit_message'
/home/amk/Opt/sup/lib/sup/modes/compose_mode.rb:20:in `default_edit_message'
/home/amk/Opt/sup/lib/sup/modes/compose_mode.rb:34:in `spawn_nicely'
./bin/sup:324:in `<module:Redwood>'
./bin/sup:83:in `<main>'
```
