### PR TITLE
fix license value to GPL-2.0

### DIFF
--- a/sup.gemspec
+++ b/sup.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email   = "supmua@googlegroups.com"
   s.summary = "A console-based email client with the best features of GMail, mutt and Emacs"
   s.homepage = "http://supmua.org"
-  s.license = 'GPL-2'
+  s.license = 'GPL-2.0'
   s.description = <<-DESC
     Sup is a console-based email client for people with a lot of email.
 


### PR DESCRIPTION
getting a warning from rubygems. assuming 2.0 is correct

>WARNING:  license value 'GPL-2' is invalid.  Use a license identifier from
>http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.